### PR TITLE
Zenodo Review Peter

### DIFF
--- a/data/b3data_package/datapackage.json
+++ b/data/b3data_package/datapackage.json
@@ -11,15 +11,19 @@
       "encoding": "utf-8",
       "title": "Occurrence cube for birds in Belgium (MGRS 10 km)",
       "description": "Occurrence cube for birds in Belgium between 2000 en 2024. The taxonomical resolution is 'species' and the temporal resolution is 'year' Spatial aggregation is done using the MGRS grid at 10 km scale. Only grid cells that fall within the 10 km MGRS reference grid for mainland Belgium (see b3data: `mgrs10_refgrid_belgium.geojson`) are included.",
-      "sources": {
-        "title": "GBIF Occurrence Download",
-        "path": "https://doi.org/10.15468/dl.y3wpwk"
-      },
-      "licenses": {
-        "name": "CC BY-NC 4.0",
-        "path": "https://creativecommons.org/licenses/by-nc/4.0/",
-        "title": "Creative Commons Attribution-NonCommercial 4.0 International"
-      },
+      "sources": [
+        {
+          "title": "GBIF Occurrence Download",
+          "path": "https://doi.org/10.15468/dl.y3wpwk"
+        }
+      ],
+      "licenses": [
+        {
+          "name": "CC BY-NC 4.0",
+          "path": "https://creativecommons.org/licenses/by-nc/4.0/",
+          "title": "Creative Commons Attribution-NonCommercial 4.0 International"
+        }
+      ],
       "schema": {
         "fields": [
           {
@@ -60,15 +64,16 @@
     {
       "name": "mgrs10_refgrid_belgium",
       "path": "mgrs10_refgrid_belgium.geojson",
-      "profile": "spatial-data-resource",
       "format": "geojson",
       "title": "MGRS 10 Km reference grid Belgium",
       "description": "MGRS 10 Km reference grid for the mainland of Belgium.",
-      "licenses": {
-        "name": "CC0 1.0",
-        "path": "https://creativecommons.org/publicdomain/zero/1.0/",
-        "title": "Creative Commons Zero v1.0 Universal"
-      }
+      "licenses": [
+        {
+          "name": "CC0 1.0",
+          "path": "https://creativecommons.org/publicdomain/zero/1.0/",
+          "title": "Creative Commons Zero v1.0 Universal"
+        }
+      ]
     }
   ],
   "title": "b3data: Data resources for the b3verse",

--- a/data/b3data_package/datapackage.json
+++ b/data/b3data_package/datapackage.json
@@ -28,7 +28,7 @@
         "fields": [
           {
             "name": "year",
-            "type": "number"
+            "type": "integer"
           },
           {
             "name": "mgrscode",
@@ -36,7 +36,7 @@
           },
           {
             "name": "specieskey",
-            "type": "number"
+            "type": "integer"
           },
           {
             "name": "species",
@@ -48,7 +48,7 @@
           },
           {
             "name": "n",
-            "type": "number"
+            "type": "integer"
           },
           {
             "name": "mincoordinateuncertaintyinmeters",
@@ -56,7 +56,7 @@
           },
           {
             "name": "familycount",
-            "type": "number"
+            "type": "integer"
           }
         ]
       }

--- a/data/b3data_package/datapackage.json
+++ b/data/b3data_package/datapackage.json
@@ -19,7 +19,7 @@
       ],
       "licenses": [
         {
-          "name": "CC BY-NC 4.0",
+          "name": "CC-BY-NC-4.0",
           "path": "https://creativecommons.org/licenses/by-nc/4.0/",
           "title": "Creative Commons Attribution-NonCommercial 4.0 International"
         }
@@ -65,11 +65,11 @@
       "name": "mgrs10_refgrid_belgium",
       "path": "mgrs10_refgrid_belgium.geojson",
       "format": "geojson",
-      "title": "MGRS 10 Km reference grid Belgium",
-      "description": "MGRS 10 Km reference grid for the mainland of Belgium.",
+      "title": "MGRS 10 km reference grid Belgium",
+      "description": "MGRS 10 km reference grid for the mainland of Belgium.",
       "licenses": [
         {
-          "name": "CC0 1.0",
+          "name": "CC0-1.0",
           "path": "https://creativecommons.org/publicdomain/zero/1.0/",
           "title": "Creative Commons Zero v1.0 Universal"
         }
@@ -80,7 +80,7 @@
   "description": "This data package contains data resources to be used across the b3verse (https://docs.b-cubed.eu/guides/b3verse/). This includes example datasets (occurrence cubes) as well as spatial resources like reference grids or raster data.",
   "keywords": ["data cubes", "b3verse", "frictionless", "biodiversity"],
   "licenses": {
-    "name": "CC BY-NC 4.0",
+    "name": "CC-BY-NC-4.0",
     "path": "https://creativecommons.org/licenses/by-nc/4.0/",
     "title": "Creative Commons Attribution-NonCommercial 4.0 International"
   },

--- a/data/b3data_package/datapackage.json
+++ b/data/b3data_package/datapackage.json
@@ -1,6 +1,7 @@
 {
   "name": "b3data",
-  "id": "https://doi.org/10.5281/zenodo.15181097",
+  "id": "https://doi.org/10.5281/zenodo.15181098",
+  "version": "0.1.0",
   "resources": [
     {
       "name": "bird_cube_belgium_mgrs10",
@@ -74,34 +75,6 @@
           "title": "Creative Commons Zero v1.0 Universal"
         }
       ]
-    }
-  ],
-  "title": "b3data: Data resources for the b3verse",
-  "description": "This data package contains data resources to be used across the b3verse (https://docs.b-cubed.eu/guides/b3verse/). This includes example datasets (occurrence cubes) as well as spatial resources like reference grids or raster data.",
-  "keywords": ["data cubes", "b3verse", "frictionless", "biodiversity"],
-  "licenses": {
-    "name": "CC-BY-NC-4.0",
-    "path": "https://creativecommons.org/licenses/by-nc/4.0/",
-    "title": "Creative Commons Attribution-NonCommercial 4.0 International"
-  },
-  "version": "0.1.0",
-  "sources": {
-    "title": "b3data-scripts",
-    "path": "https://github.com/b-cubed-eu/b3data-scripts"
-  },
-  "contributors": [
-    {
-      "title": "Ward Langeraert",
-      "path": "https://orcid.org/0000-0002-5900-8109",
-      "email": "ward.langeraert@inbo.be",
-      "role": "author",
-      "organization": "Research Institute for Nature and Forest (INBO)"
-    },
-    {
-      "title": "Toon Van Daele",
-      "path": "https://orcid.org/0000-0002-1362-853X",
-      "role": "contributor",
-      "organization": "Research Institute for Nature and Forest (INBO)"
     }
   ]
 }

--- a/source/add_spatial_resources.Rmd
+++ b/source/add_spatial_resources.Rmd
@@ -57,7 +57,6 @@ Example:
 
 Each dataset includes the following metadata (see: [Frictionless resource spec](https://docs.ropensci.org/frictionless/articles/data-resource.html#properties-implementation)):
 
-- **profile**: `spatial-data-resource`
 - **format**: e.g. `geojson`
 - **title**: e.g. `"MGRS 10 km reference grid for Belgium"`
 - **description**: concise explanation of content
@@ -103,15 +102,14 @@ b3data_package <- read_package(file.path(package_path, "datapackage.json"))
 mgrs10_resource <- list(
   name = "mgrs10_refgrid_belgium",
   path = "mgrs10_refgrid_belgium.geojson",
-  profile = "spatial-data-resource",
   format = "geojson",
   title = "MGRS 10 Km reference grid Belgium",
   description = "MGRS 10 Km reference grid for the mainland of Belgium.",
-  licenses = list(
+  licenses = list(list(
     name = "CC0 1.0",
     path = "https://creativecommons.org/publicdomain/zero/1.0/",
     title = "Creative Commons Zero v1.0 Universal"
-    )
+    ))
   )
 
 b3data_package <- add_manual_resource(

--- a/source/add_spatial_resources.Rmd
+++ b/source/add_spatial_resources.Rmd
@@ -64,7 +64,7 @@ Each dataset includes the following metadata (see: [Frictionless resource spec](
 - **licenses**: [CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/)
 
 # Datasets
-## MGRS 10 Km reference grid Belgium
+## MGRS 10 km reference grid Belgium
 
 Load the data.
 
@@ -103,10 +103,10 @@ mgrs10_resource <- list(
   name = "mgrs10_refgrid_belgium",
   path = "mgrs10_refgrid_belgium.geojson",
   format = "geojson",
-  title = "MGRS 10 Km reference grid Belgium",
-  description = "MGRS 10 Km reference grid for the mainland of Belgium.",
+  title = "MGRS 10 km reference grid Belgium",
+  description = "MGRS 10 km reference grid for the mainland of Belgium.",
   licenses = list(list(
-    name = "CC0 1.0",
+    name = "CC0-1.0",
     path = "https://creativecommons.org/publicdomain/zero/1.0/",
     title = "Creative Commons Zero v1.0 Universal"
     ))

--- a/source/create_b3data_package.Rmd
+++ b/source/create_b3data_package.Rmd
@@ -171,15 +171,15 @@ b3data_package <- create_package() %>%
       "Only grid cells that fall within the 10 km MGRS reference grid for",
       "mainland Belgium (see b3data: `mgrs10_refgrid_belgium.geojson`) are",
       "included."),
-    sources = list(
+    sources = list(list(
       title = "GBIF Occurrence Download",
       path = "https://doi.org/10.15468/dl.y3wpwk"
-    ),
-    licenses = list(
+    )),
+    licenses = list(list(
       name = "CC BY-NC 4.0",
       path = "https://creativecommons.org/licenses/by-nc/4.0/",
       title = "Creative Commons Attribution-NonCommercial 4.0 International"
-    )
+    ))
   )
 ```
 

--- a/source/create_b3data_package.Rmd
+++ b/source/create_b3data_package.Rmd
@@ -72,17 +72,12 @@ Each dataset includes the following metadata (see: [Frictionless resource spec](
 
 ## Package-level Metadata
 
-Metadata for the entire data package (see: [Frictionless Data Package spec](https://specs.frictionlessdata.io/data-package/#metadata)):
+Metadata for the entire data package (see: [Frictionless Data Package spec](https://specs.frictionlessdata.io/data-package/#metadata)).
+This will be rather limited to avoid repetition with metadata of Zenodo deposit:
 
 - **name**: `b3data`
-- **id**: reserved Zenodo DOI
-- **title**: `b3data: Data resources for the b3verse`
-- **description**: overview of purpose, content, and structure of the data package
-- **keywords**: e.g. `"biodiversity", "data cube", "b3verse", "GBIF", "frictionless"`
-- **licenses**: [CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/)
+- **id**: reserved Zenodo DOI (version specific)
 - **version**: semantic versioning string, e.g. 0.1.0
-- **sources**: GitHub repository [b3data-scripts](https://github.com/b-cubed-eu/b3data-scripts)
-- **contributors**: name, ORCID, and roles
 
 # Datasets
 ## Birds in Belgium (MGRS 10 km)
@@ -198,62 +193,11 @@ b3data_package <- append(b3data_package,
                          c(name = "b3data"),
                          after = 0)
 b3data_package <- append(b3data_package,
-                         c(id = "https://doi.org/10.5281/zenodo.15181097"),
+                         c(id = "https://doi.org/10.5281/zenodo.15181098"),
                          after = 1)
 b3data_package <- append(b3data_package,
-                         c(title = "b3data: Data resources for the b3verse"),
-                         after = 3)
-b3data_package <- append(
-  b3data_package,
-  c(description = paste(
-    "This data package contains data resources to be used across the b3verse",
-    "(https://docs.b-cubed.eu/guides/b3verse/).",
-    "This includes example datasets (occurrence cubes) as well as spatial",
-    "resources like reference grids or raster data."
-  )),
-  after = 4)
-b3data_package <- append(
-  b3data_package,
-  c(keywords = list(list(
-    "data cubes", "b3verse", "frictionless", "biodiversity"
-    ))),
-  after = 5)
-b3data_package <- append(
-  b3data_package,
-  c(licenses = list(list(
-    name = "CC-BY-NC-4.0",
-    path = "https://creativecommons.org/licenses/by-nc/4.0/",
-    title = "Creative Commons Attribution-NonCommercial 4.0 International"
-    ))),
-  after = 6)
-b3data_package <- append(b3data_package,
                          c(version = "0.1.0"),
-                         after = 7)
-b3data_package <- append(
-  b3data_package,
-  c(sources = list(list(
-    title = "b3data-scripts",
-    path = "https://github.com/b-cubed-eu/b3data-scripts"
-    ))),
-  after = 8)
-b3data_package <- append(
-  b3data_package,
-  c(contributors = list(list(
-    list(
-      title = "Ward Langeraert",
-      path = "https://orcid.org/0000-0002-5900-8109",
-      email = "ward.langeraert@inbo.be",
-      role = "author",
-      organization = "Research Institute for Nature and Forest (INBO)"
-      ),
-    list(
-      title = "Toon Van Daele",
-      path = "https://orcid.org/0000-0002-1362-853X",
-      role = "contributor",
-      organization = "Research Institute for Nature and Forest (INBO)"
-      )
-    ))),
-  after = 9)
+                         after = 2)
 
 # Warning: append() drops the custom datapackage class.
 # It can be added again by running b3data_package through create_package()

--- a/source/create_b3data_package.Rmd
+++ b/source/create_b3data_package.Rmd
@@ -176,7 +176,7 @@ b3data_package <- create_package() %>%
       path = "https://doi.org/10.15468/dl.y3wpwk"
     )),
     licenses = list(list(
-      name = "CC BY-NC 4.0",
+      name = "CC-BY-NC-4.0",
       path = "https://creativecommons.org/licenses/by-nc/4.0/",
       title = "Creative Commons Attribution-NonCommercial 4.0 International"
     ))
@@ -219,7 +219,7 @@ b3data_package <- append(
 b3data_package <- append(
   b3data_package,
   c(licenses = list(list(
-    name = "CC BY-NC 4.0",
+    name = "CC-BY-NC-4.0",
     path = "https://creativecommons.org/licenses/by-nc/4.0/",
     title = "Creative Commons Attribution-NonCommercial 4.0 International"
     ))),

--- a/source/create_b3data_package.Rmd
+++ b/source/create_b3data_package.Rmd
@@ -152,7 +152,9 @@ ggplot() + geom_sf(data = utm10_bel)
 ```{r}
 # Only select grid cells from reference grid
 bird_cube_belgium_mgrs10 <- bird_cube_belgium_mgrs10_full %>%
-  filter(substring(mgrscode, 4) %in% utm10_bel$TAG)
+  filter(substring(mgrscode, 4) %in% utm10_bel$TAG) %>%
+  # Transform columns to integers
+  mutate(across(c("year", "specieskey", "n", "familycount"), as.integer))
 ```
 
 We create the package and add the dataset.


### PR DESCRIPTION
see [this gist](https://gist.github.com/peterdesmet/5358ad7f4789964b2f65650c5d6cbd50/revisions)

Validation errors:
- [x] The licenses and sources need to be an array ([ { } ])
- [x] The mgrs10_refgrid_belgium has a profile spatial-data-resource which is not a recognized profile. It is not tabular either, so you can just remove the profile property

Recommendations:
- [x] Technically, the license name should be written with dashes (since they are identifiers from https://licenses.opendefinition.org/licenses/groups/all.json)
- [x] The numeric fields (except for mincoordinateuncertaintyinmeters) can be defined as integer
- [x] Write Km as km

Redundant dataset-level metadata (already in Zenodo metadata):

- [x] name: can be kept
- [x] id: I would set this to the versioned doi https://doi.org/10.5281/zenodo.15181098 so that if you read the file, you know which version it is.
- [x] title: remove
- [x] description: remove
- [x] keywords: remove
- [x] licenses: remove (also note that you technically should have 2 licenses here)
- [x] version: remove (or keep if you prefer to indicate cf. DOI)
- [x] sources: remove, you already list this in Related works
- [x] contributors: remove
